### PR TITLE
#12 migrate terraform from local to cloud using a block

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,7 @@
 tasks:
   - name: terraform
     before: |
-      sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl
-      curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-      sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" -y
-      sudo apt-get update && sudo apt-get install terraform
+      source ./bin/install_terraform_cli
   - name: aws-cli
     env:
       AWS_CLI_AUTO_PROMPT: on-partial

--- a/README.md
+++ b/README.md
@@ -66,3 +66,37 @@ Env Vars are stored in both the Gitpod Global Variables, as well as the individu
 aws sts get-caller-identity
 ```
 
+### Congfiguring main.tf Providers
+
+When you configure you're provider, you'll need to make sure you add lines for authentication:
+
+```
+provider "aws" {
+  region     = "us-west-2"
+  access_key = "my-access-key"
+  secret_key = "my-secret-key"
+}
+```
+*** ^^ THIS IS BAD - DON'T DO THIS**
+This method is insecure, because it involves placing your secure keys in clear-text within your configuration file, which is an obvious security concern.
+
+If you only have set your Access Keys in your Global Variables for your Workspace, it you won't be able to finish your init - because the provider config has nothing to reference. You have to specifically call our your env var's using **export**:
+
+```
+export AWS_ACCESS_KEY_ID="anaccesskey"
+export AWS_SECRET_ACCESS_KEY="asecretkey"
+export AWS_REGION="us-west-2"
+terraform plan
+```
+
+[Authentication and Configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration)
+
+### Terraform Cloud
+
+If you're using the Terraform Cloud block in your configuration file, you're telling your configuration environment to run IN the cloud, versus locally in your editor, so you need to remember to set environment variables IN the cloud GUI, so that environment can make use of them when referencing whatever API's it needs
+
+From the Terraform Cloud Login page:
+
+```"Terraform Cloud runs Terraform operations and stores state remotely, so you can use Terraform without worrying about the stability of your local machine, or the security of your state file."```
+
+[Terraform Cloud Login](https://developer.hashicorp.com/terraform/tutorials/cloud-get-started/cloud-login)

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,10 @@
 terraform {
+  cloud {
+    organization = "alec_terra_org"
+    workspaces {
+      name = "terra-house-1"
+    }
+  }
   required_providers {
     random = {
       source = "hashicorp/random"
@@ -9,6 +15,10 @@ terraform {
       version = "5.17.0"
     }
   }
+}
+
+provider "aws" {
+  # Configuration options
 }
 
 provider "random" {
@@ -32,3 +42,4 @@ resource "aws_s3_bucket" "example" {
   # Bucket Name Rules: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
   bucket = random_string.bucket_name.result
 }
+


### PR DESCRIPTION
Configure Terraform Cloud Block
Workaround for Terraform Login
Migrate local state to remote state
Create new Project and Workspace in Terraform Cloud

Did not use the workaround this time, as we were able to manually enter the "terraform login" credentials, and may set up that automation later